### PR TITLE
Keep clip reorder in sync with sequencer

### DIFF
--- a/src/renderer/audio/AudioManager.ts
+++ b/src/renderer/audio/AudioManager.ts
@@ -335,15 +335,22 @@ export class AudioManager {
         const newIndices = [...state.timeline.reorderIndices];
         const [movedIndex] = newIndices.splice(fromIndex, 1);
         newIndices.splice(toIndex, 0, movedIndex);
-        
-        // Update sequencer with new order
-        const reorderedClips = newIndices.map(i => state.timeline.clips[i]);
+
+        // Update clip.order values to reflect the new sequence
+        const newClips = state.timeline.clips.map((clip, originalIdx) => ({
+          ...clip,
+          order: newIndices.indexOf(originalIdx),
+        }));
+
+        // Inform sequencer using the reordered clip array
+        const reorderedClips = newIndices.map(i => newClips[i]);
         this.sequencer.updateClips(reorderedClips);
-        
+
         return {
           ...state,
           timeline: {
             ...state.timeline,
+            clips: newClips,
             reorderIndices: newIndices,
             totalDuration: this.calculateTotalDuration(),
           },

--- a/src/renderer/audio/JuceAudioManager.ts
+++ b/src/renderer/audio/JuceAudioManager.ts
@@ -334,11 +334,25 @@ export class JuceAudioManager {
         const newIndices = [...state.timeline.reorderIndices];
         const [movedIndex] = newIndices.splice(fromIndex, 1);
         newIndices.splice(toIndex, 0, movedIndex);
-        const reorderedClips = newIndices.map((i) => state.timeline.clips[i]);
+
+        // Update clip.order values to reflect the new playback order
+        const newClips = state.timeline.clips.map((clip, originalIdx) => ({
+          ...clip,
+          order: newIndices.indexOf(originalIdx),
+        }));
+
+        // Update sequencer with clips already in the new order
+        const reorderedClips = newIndices.map((i) => newClips[i]);
         this.sequencer.updateClips(reorderedClips);
+
         return {
           ...state,
-          timeline: { ...state.timeline, reorderIndices: newIndices, totalDuration: this.calculateTotalDuration(state.timeline.clips, state.timeline.deletedWordIds) },
+          timeline: {
+            ...state.timeline,
+            clips: newClips,
+            reorderIndices: newIndices,
+            totalDuration: this.calculateTotalDuration(newClips, state.timeline.deletedWordIds),
+          },
         };
       }
       case 'DELETE_CLIP': {

--- a/src/renderer/audio/SimpleClipSequencer.ts
+++ b/src/renderer/audio/SimpleClipSequencer.ts
@@ -27,9 +27,12 @@ export class SimpleClipSequencer {
    * Calculate clips in their reordered sequence
    */
   private calculateReorderedClips(clips: Clip[]): Clip[] {
-    return clips
-      .filter(clip => clip.status !== 'deleted') // Allow active and undefined status
-      .sort((a, b) => (a.order || 0) - (b.order || 0)); // Handle undefined order
+    // The order of clips is now determined by the array passed into updateClips.
+    // Previously this function re-sorted based on clip.order which could get out
+    // of sync with the caller's desired ordering. By relying purely on array
+    // order we ensure the sequencer reflects the timeline order maintained by
+    // the AudioManagers.
+    return clips.filter(clip => clip.status !== 'deleted');
   }
   
   /**

--- a/src/renderer/audio/__tests__/reorder.seek.spec.ts
+++ b/src/renderer/audio/__tests__/reorder.seek.spec.ts
@@ -1,0 +1,87 @@
+import { jest } from '@jest/globals';
+import JuceAudioManager from '../../audio/JuceAudioManager';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var window: any;
+}
+
+function makeClips() {
+  const now = Date.now();
+  const mk = (id: string, start: number, end: number) => ({
+    id,
+    speaker: 'S',
+    startTime: start,
+    endTime: end,
+    startWordIndex: 0,
+    endWordIndex: 0,
+    words: [{ start, end, word: id }],
+    text: '',
+    confidence: 1,
+    type: 'transcribed' as const,
+    duration: end - start,
+    order: 0,
+    createdAt: now,
+    modifiedAt: now,
+    status: 'active' as const,
+  });
+  const clipA = mk('clipA', 0, 1);
+  const clipB = mk('clipB', 1, 2);
+  return [clipA, clipB];
+}
+
+function setupTransportMock() {
+  let cb: any = null;
+  const calls: any[] = [];
+  (global as any).window = (global as any).window || {};
+  (global as any).window.juceTransport = {
+    load: async () => ({ success: true }),
+    updateEdl: async () => ({ success: true }),
+    play: async () => ({ success: true }),
+    pause: async () => ({ success: true }),
+    stop: async () => ({ success: true }),
+    seek: async (_id: string, t: number) => {
+      calls.push(['seek', t]);
+      return { success: true };
+    },
+    setRate: async () => ({ success: true }),
+    setVolume: async () => ({ success: true }),
+    queryState: async () => ({ success: true }),
+    onEvent: (fn: any) => { cb = fn; },
+    offEvent: () => { cb = null; },
+  };
+  return { emit: (evt: any) => cb && cb(evt), calls };
+}
+
+describe('clip reordering seek behaviour', () => {
+  test('clicking a word after reordering seeks into the correct clip position', () => {
+    const { emit, calls } = setupTransportMock();
+    const mgr = new (JuceAudioManager as any)({
+      onStateChange: () => {},
+      onError: () => {},
+      onWordHighlight: () => {},
+      onClipChange: () => {},
+    });
+
+    // Bypass full initialization but mark audio ready
+    (mgr as any).state.isInitialized = true;
+    (mgr as any).state.playback.isReady = true;
+
+    const clips = makeClips(); // [A,B]
+    mgr.updateClips(clips);
+    emit({ type: 'edlApplied', id: 'default', revision: 1 });
+
+    // Move clipB before clipA
+    mgr.reorderClips(1, 0);
+    emit({ type: 'edlApplied', id: 'default', revision: 2 });
+
+    // Seek to the word in clipA (which is now second in sequence)
+    mgr.seekToWord('clipA', 0);
+
+    const seekCall = calls.filter(c => c[0] === 'seek').pop();
+    expect(seekCall).toBeDefined();
+    // After reordering, clipA should start at t=1 (duration of clipB)
+    expect(seekCall[1]).toBeCloseTo(1, 5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Stop sorting clips by `clip.order` inside `SimpleClipSequencer`
- Update `REORDER_CLIPS` reducer to update each clip's `order` and feed reordered array to the sequencer
- Add regression test verifying seeking to a word after clips are reordered

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68c838d86db88333bed5934d7f41b038