### PR TITLE
Add spacer tracing logs and EDL revision tracking

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -274,7 +274,11 @@ declare global {
     electronAPI: ElectronAPI;
     juceTransport: {
       load: (id: string, path: string) => Promise<{ success: boolean; error?: string }>;
-      updateEdl: (id: string, clips: EdlClip[]) => Promise<{ success: boolean; error?: string }>;
+      updateEdl: (
+        id: string,
+        revision: number,
+        clips: EdlClip[]
+      ) => Promise<{ success: boolean; error?: string; revision?: number; counts?: { words: number; spacers: number; total: number } }>;
       play: (id: string) => Promise<{ success: boolean; error?: string }>;
       pause: (id: string) => Promise<{ success: boolean; error?: string }>;
       stop: (id: string) => Promise<{ success: boolean; error?: string }>;
@@ -301,7 +305,8 @@ ipcRenderer.on('juce:event', (_event, evt: JuceEvent) => {
 
 contextBridge.exposeInMainWorld('juceTransport', {
   load: (id: string, path: string) => ipcRenderer.invoke('juce:load', id, path),
-  updateEdl: (id: string, clips: EdlClip[]) => ipcRenderer.invoke('juce:updateEdl', id, clips),
+  updateEdl: (id: string, revision: number, clips: EdlClip[]) =>
+    ipcRenderer.invoke('juce:updateEdl', id, revision, clips),
   play: (id: string) => ipcRenderer.invoke('juce:play', id),
   pause: (id: string) => ipcRenderer.invoke('juce:pause', id),
   stop: (id: string) => ipcRenderer.invoke('juce:stop', id),

--- a/src/renderer/audio/__tests__/juce.audioOnly.seek.spec.ts
+++ b/src/renderer/audio/__tests__/juce.audioOnly.seek.spec.ts
@@ -30,7 +30,7 @@ function setupTransportMock() {
   (global as any).window = (global as any).window || {};
   (global as any).window.juceTransport = {
     load: async () => ({ success: true }),
-    updateEdl: async () => ({ success: true }),
+    updateEdl: async (_id: string, revision: number) => ({ success: true, revision }),
     play: async () => ({ success: true }),
     pause: async () => ({ success: true }),
     stop: async () => ({ success: true }),

--- a/src/renderer/audio/__tests__/juce.sequencer-sync.spec.ts
+++ b/src/renderer/audio/__tests__/juce.sequencer-sync.spec.ts
@@ -29,7 +29,7 @@ function setupTransportMock() {
   (global as any).window = (global as any).window || {};
   (global as any).window.juceTransport = {
     load: async () => ({ success: true }),
-    updateEdl: async () => ({ success: true }),
+    updateEdl: async (_id: string, revision: number) => ({ success: true, revision }),
     play: async () => ({ success: true }),
     pause: async () => ({ success: true }),
     stop: async () => ({ success: true }),

--- a/src/renderer/audio/__tests__/juce.textOnlyDeletion.spec.ts
+++ b/src/renderer/audio/__tests__/juce.textOnlyDeletion.spec.ts
@@ -33,7 +33,10 @@ function setupTransportMock() {
   (global as any).window = (global as any).window || {};
   (global as any).window.juceTransport = {
     load: async () => ({ success: true }),
-    updateEdl: async (_id: string, edl: any[]) => { calls.push(['edl', edl]); return { success: true }; },
+    updateEdl: async (_id: string, _revision: number, edl: any[]) => {
+      calls.push(['edl', edl]);
+      return { success: true, revision: _revision };
+    },
     play: async () => ({ success: true }),
     pause: async () => ({ success: true }),
     stop: async () => ({ success: true }),

--- a/src/renderer/audio/__tests__/playback.editedOnly.spec.ts
+++ b/src/renderer/audio/__tests__/playback.editedOnly.spec.ts
@@ -40,7 +40,7 @@ function setupTransportMock() {
   (global as any).window = (global as any).window || {};
   (global as any).window.juceTransport = {
     load: async () => ({ success: true }),
-    updateEdl: async () => ({ success: true }),
+    updateEdl: async (_id: string, revision: number) => ({ success: true, revision }),
     play: async () => ({ success: true }),
     pause: async () => ({ success: true }),
     stop: async () => ({ success: true }),

--- a/src/renderer/audio/__tests__/reorder.seek.spec.ts
+++ b/src/renderer/audio/__tests__/reorder.seek.spec.ts
@@ -36,7 +36,7 @@ function setupTransportMock() {
   (global as any).window = (global as any).window || {};
   (global as any).window.juceTransport = {
     load: async () => ({ success: true }),
-    updateEdl: async () => ({ success: true }),
+    updateEdl: async (_id: string, revision: number) => ({ success: true, revision }),
     play: async () => ({ success: true }),
     pause: async () => ({ success: true }),
     stop: async () => ({ success: true }),

--- a/src/renderer/services/TranscriptionImportService.ts
+++ b/src/renderer/services/TranscriptionImportService.ts
@@ -60,6 +60,41 @@ export class TranscriptionImportService {
     const clips = this.createClipsFromWords(allWords, speakers || {});
     console.log(`🎬 Created ${clips.length} clips from speaker groups`);
 
+    let totalWordSegments = 0;
+    let totalSpacerSegments = 0;
+    let firstSpacerExample: { clipOrder: number; clipId: string; start: number; end: number; duration: number } | null = null;
+
+    clips.forEach((clip, index) => {
+      let words = 0;
+      let spacers = 0;
+      for (const segment of clip.segments) {
+        if (segment.type === 'spacer') {
+          spacers += 1;
+          totalSpacerSegments += 1;
+          if (!firstSpacerExample) {
+            firstSpacerExample = {
+              clipOrder: clip.order ?? index,
+              clipId: clip.id,
+              start: Number(segment.start.toFixed(3)),
+              end: Number(segment.end.toFixed(3)),
+              duration: Number((segment.end - segment.start).toFixed(3))
+            };
+          }
+        } else {
+          words += 1;
+          totalWordSegments += 1;
+        }
+      }
+      console.log(`📊 Clip[${index}] ${clip.id.slice(-8)} — ${words} words / ${spacers} spacers`);
+    });
+
+    if (firstSpacerExample) {
+      console.log('🧩 First spacer example:', firstSpacerExample);
+    } else {
+      console.warn('⚠️ No spacer segments were generated during import.');
+    }
+    console.log(`📦 Segment totals after import: ${totalWordSegments} words, ${totalSpacerSegments} spacers`);
+
     // Step 3: Build project data structure
     const projectData: ProjectData = {
       version: '2.0',

--- a/src/renderer/types/juceTransport.d.ts
+++ b/src/renderer/types/juceTransport.d.ts
@@ -4,7 +4,11 @@ declare global {
   interface Window {
     juceTransport: {
       load: (id: string, path: string) => Promise<{ success: boolean; error?: string }>;
-      updateEdl: (id: string, clips: EdlClip[]) => Promise<{ success: boolean; error?: string }>;
+      updateEdl: (
+        id: string,
+        revision: number,
+        clips: EdlClip[]
+      ) => Promise<{ success: boolean; error?: string; revision?: number; counts?: { words: number; spacers: number; spacersWithOriginal?: number; total: number } }>;
       play: (id: string) => Promise<{ success: boolean; error?: string }>;
       pause: (id: string) => Promise<{ success: boolean; error?: string }>;
       stop: (id: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
## Summary
- add detailed spacer and word logging during import and renderer EDL construction, including revision tracking and spacer previews
- extend preload, IPC, and JUCE client plumbing to carry revision metadata, segment statistics, and enhanced diagnostics into edl_debug files
- update the JUCE backend to log parsed spacer counts, emit edlApplied events with segment totals, and report playback mode per revision

## Testing
- `npm test -- --runTestsByPath src/renderer/audio/__tests__/juce.audioOnly.seek.spec.ts` *(fails: jest not installed in environment)*
- `npm install` *(fails: dependency conflict from @testing-library/react-hooks peer requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b77926388333bb6ab808ec2cdcdd