### PR TITLE
Trace spacer segments through import and JUCE pipeline

### DIFF
--- a/native/juce-backend/src/main.cpp
+++ b/native/juce-backend/src/main.cpp
@@ -862,6 +862,17 @@ public:
     lastWordSegments = wordSegments;
     lastSpacerSegments = spacerSegments;
 
+    {
+      std::ostringstream oss;
+      oss << "[JUCE] Parsed EDL revision " << revision
+          << ": clips=" << clips.size()
+          << ", words=" << wordSegments
+          << ", spacers=" << spacerSegments
+          << ", total=" << totalSegments
+          << ", mode=" << (isContiguousTimeline ? "contiguous" : "standard");
+      juceDLog(oss.str());
+    }
+
     // Enhanced debug logging - write to file to see what JUCE receives
     std::ofstream debugFile(juceDebugPath(), std::ios::app);
     debugFile << "[JUCE] updateEdl received revision " << revision
@@ -1012,7 +1023,10 @@ public:
       }
     }
 
-    debugFile << "[JUCE] updateEdl segment breakdown complete for revision " << revision << std::endl;
+    const std::string mode = isContiguousTimeline ? "contiguous" : "standard";
+
+    debugFile << "[JUCE] updateEdl segment breakdown complete for revision " << revision
+              << ", mode=" << mode << std::endl;
     debugFile.flush();
 
     {
@@ -1020,7 +1034,8 @@ public:
       evt << "{\"type\":\"edlApplied\",\"id\":\"" << g.id << "\",\"revision\":" << revision
           << ",\"wordCount\":" << wordSegments
           << ",\"spacerCount\":" << spacerSegments
-          << ",\"totalSegments\":" << totalSegments << "}";
+          << ",\"totalSegments\":" << totalSegments
+          << ",\"mode\":\"" << mode << "\"}";
       emit(evt.str());
     }
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -386,6 +386,8 @@ class App {
             end: number;
             duration: number;
             hasOriginal: boolean;
+            originalStart?: number;
+            originalEnd?: number;
           }>,
         };
 
@@ -406,6 +408,12 @@ class App {
                   end: Number(segment.endSec.toFixed(3)),
                   duration: Number((segment.endSec - segment.startSec).toFixed(3)),
                   hasOriginal: typeof segment.originalStartSec === 'number' && typeof segment.originalEndSec === 'number',
+                  originalStart: typeof segment.originalStartSec === 'number'
+                    ? Number(segment.originalStartSec.toFixed(3))
+                    : undefined,
+                  originalEnd: typeof segment.originalEndSec === 'number'
+                    ? Number(segment.originalEndSec.toFixed(3))
+                    : undefined,
                 });
               }
             } else {
@@ -467,6 +475,7 @@ class App {
             revision: e.revision,
             wordCount: (e as any).wordCount,
             spacerCount: (e as any).spacerCount,
+            mode: (e as any).mode,
           });
           forward(e);
         },
@@ -521,6 +530,7 @@ class App {
             words: stats.wordSegments,
             spacers: stats.spacerSegments,
             spacersWithOriginal: stats.spacersWithOriginal,
+            spacerPreview: stats.spacerPreview,
           });
           if (stats.spacerSegments === 0) {
             console.warn('[IPC][JUCE] ⚠️ No spacers detected in renderer payload for revision', rev);

--- a/src/renderer/audio/JuceAudioManager.ts
+++ b/src/renderer/audio/JuceAudioManager.ts
@@ -565,6 +565,7 @@ export class JuceAudioManager {
               words: (evt as any).wordCount,
               spacers: (evt as any).spacerCount,
               totalSegments: (evt as any).totalSegments,
+              mode: (evt as any).mode,
             });
           }
         }
@@ -574,6 +575,7 @@ export class JuceAudioManager {
             words: (evt as any).wordCount,
             spacers: (evt as any).spacerCount,
             totalSegments: (evt as any).totalSegments,
+            mode: (evt as any).mode,
           });
         }
         // Clear EDL applying flag and flush any pending seek

--- a/src/renderer/audio/JuceAudioManagerV2.ts
+++ b/src/renderer/audio/JuceAudioManagerV2.ts
@@ -461,7 +461,10 @@ export class JuceAudioManagerV2 {
 
       case 'edlApplied': {
         const expectedRevision = this.edlRevisionCounter;
-        console.info(`[AudioManager] EDL applied by JUCE (revision ${event.revision}, expected ${expectedRevision})`);
+        const mode = (event as any).mode;
+        console.info(
+          `[AudioManager] EDL applied by JUCE (revision ${event.revision}, expected ${expectedRevision}, mode ${mode ?? 'unknown'})`
+        );
         if (event.revision !== expectedRevision) {
           console.warn('[AudioManager] ⚠️ EDL revision mismatch!', {
             received: event.revision,

--- a/src/shared/types/transport.ts
+++ b/src/shared/types/transport.ts
@@ -42,7 +42,15 @@ export type JuceEvent =
   | { type: 'loaded'; id: TransportId; durationSec: number; sampleRate: number; channels: number }
   | { type: 'state'; id: TransportId; playing: boolean }
   | { type: 'position'; id: TransportId; editedSec: number; originalSec: number; revision?: number }
-  | { type: 'edlApplied'; id: TransportId; revision: number; wordCount?: number; spacerCount?: number; totalSegments?: number }
+  | {
+      type: 'edlApplied';
+      id: TransportId;
+      revision: number;
+      wordCount?: number;
+      spacerCount?: number;
+      totalSegments?: number;
+      mode?: 'contiguous' | 'standard' | string;
+    }
   | { type: 'ended'; id: TransportId }
   | { type: 'error'; id?: TransportId; code?: string | number; message: string };
 
@@ -101,7 +109,8 @@ export function isJuceEvent(obj: any): obj is JuceEvent {
         typeof obj.revision === 'number' &&
         (obj.wordCount === undefined || typeof obj.wordCount === 'number') &&
         (obj.spacerCount === undefined || typeof obj.spacerCount === 'number') &&
-        (obj.totalSegments === undefined || typeof obj.totalSegments === 'number')
+        (obj.totalSegments === undefined || typeof obj.totalSegments === 'number') &&
+        (obj.mode === undefined || typeof obj.mode === 'string')
       );
     case 'ended':
       return typeof obj.id === 'string';


### PR DESCRIPTION
## Summary
- add detailed spacer creation logging in `TranscriptionImportService` and warn when clips generate no spacers
- log spacer counts/preview when building and pushing EDLs, propagate previews through IPC debug dumps, and expose the spacer mode information to the renderer types
- update the JUCE backend to report spacer counts/mode, emit enhanced `edlApplied` payloads, and log the parsed segment breakdown for debugging

## Testing
- npm run build:main *(fails: project lacks Node/Electron type definitions and Buffer globals)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e44f097883338a6995bdd475817c