### PR TITLE
Improve import audio handling and segment normalization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "podcast-transcriber",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "podcast-transcriber",
-      "version": "0.1.0",
+      "version": "2.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1984,16 +1984,22 @@ class App {
         );
 
         stage.current = 'validate-audio-path';
-        const assembledAudioPath = projectData?.project?.audio?.path;
+        const audio = projectData?.project?.audio;
+        const assembledAudioPath =
+          (audio?.originalFile && fs.existsSync(audio.originalFile))
+            ? audio.originalFile
+            : null;
+
         if (!assembledAudioPath) {
-          console.error('[Import][Error] missing audio path post-assembly', {
+          console.error('[Import][Error] missing playable audio path after assembly', {
             projectId: projectData?.project?.projectId,
+            audioMeta: audio,
             incomingPath,
             resolvedAudioPath,
             candidates: prepared.candidates,
             probedDirs: prepared.probedDirs,
           });
-          throw new Error('Missing audio path after import assembly');
+          throw new Error('No playable audio path (expected absolute 48 kHz WAV in audio.originalFile)');
         }
 
         console.log('[Import][Project] audioPath verified for transport', {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1983,6 +1983,24 @@ class App {
           properAudioMetadata
         );
 
+        stage.current = 'validate-audio-path';
+        const assembledAudioPath = projectData?.project?.audio?.path;
+        if (!assembledAudioPath) {
+          console.error('[Import][Error] missing audio path post-assembly', {
+            projectId: projectData?.project?.projectId,
+            incomingPath,
+            resolvedAudioPath,
+            candidates: prepared.candidates,
+            probedDirs: prepared.probedDirs,
+          });
+          throw new Error('Missing audio path after import assembly');
+        }
+
+        console.log('[Import][Project] audioPath verified for transport', {
+          path: assembledAudioPath,
+          exists: fs.existsSync(assembledAudioPath),
+        });
+
         const clipCount = projectData?.clips?.clips?.length ?? 0;
         stage.current = 'store';
         this.projectDataStore.loadProject(projectData);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -567,6 +567,15 @@ class App {
       // IPC command handlers
       ipcMain.handle('juce:load', async (_e, id: string, filePath: string, generationId?: number) => {
         try {
+          console.log('[Main] load received', { id, gen: generationId, path: filePath });
+          const absolutePath = path.isAbsolute(filePath) ? filePath : path.resolve(filePath);
+          const exists = filePath ? fs.existsSync(absolutePath) : false;
+          console.log('[Main] load resolved path', {
+            id,
+            gen: generationId,
+            absolutePath,
+            exists,
+          });
           const ext = (path.extname(filePath || '') || '').replace('.', '').toLowerCase() || 'unknown';
           if (typeof generationId === 'number') {
             const prevGen = generationById.get(id);

--- a/src/main/services/ImportAudioService.ts
+++ b/src/main/services/ImportAudioService.ts
@@ -1,0 +1,250 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { spawn } from 'child_process';
+
+export interface PreparedAudioResult {
+  originalPath: string | null;
+  resolvedPath: string;
+  metadata: WavMetadata;
+  wasConverted: boolean;
+}
+
+export interface WavMetadata {
+  sampleRate: number;
+  channels: number;
+  bitDepth: number;
+  durationSec: number;
+}
+
+const WAV_EXTENSION = '.wav';
+const TARGET_SAMPLE_RATE = 48000;
+const TARGET_CHANNELS = 2;
+const ALLOWED_BIT_DEPTHS = new Set([16, 24, 32]);
+
+export async function prepareAudioForImport(
+  incomingPath: string | undefined,
+  audioMetadata: any
+): Promise<PreparedAudioResult> {
+  const candidates = collectCandidates(incomingPath, audioMetadata);
+  const probedDirs = Array.from(new Set(candidates.map(candidate => path.dirname(candidate))));
+
+  const resolvedPath = candidates.find(candidate => fs.existsSync(candidate)) || null;
+  if (!resolvedPath) {
+    console.error('[Import][Error] NO SOURCE AUDIO FOUND', {
+      projectData: {
+        incomingPath,
+        audioMetadata,
+      },
+      probedDirs,
+    });
+    throw new Error('NO SOURCE AUDIO FOUND');
+  }
+
+  const originalPath = resolvedPath;
+
+  let finalPath = resolvedPath;
+  let wasConverted = false;
+
+  let inspection = inspectWavHeaderSafe(resolvedPath);
+  if (!inspection || !isTargetWav(inspection)) {
+    const convertedPath = await convertToTargetWav(resolvedPath);
+    wasConverted = true;
+    console.log('[Import][Audio] converted', {
+      originalPath: resolvedPath,
+      convertedPath,
+    });
+    inspection = inspectWavHeaderSafe(convertedPath);
+    if (!inspection) {
+      console.error('[Import][Error] Audio validation failed', {
+        originalPath,
+        resolvedPath: convertedPath,
+        reason: 'Converted file is not a valid WAV',
+      });
+      throw new Error('Audio validation failed');
+    }
+    if (!isTargetWav(inspection)) {
+      console.error('[Import][Error] Audio validation failed', {
+        originalPath,
+        resolvedPath: convertedPath,
+        reason: `Converted WAV does not meet 48kHz stereo requirements (rate=${inspection.sampleRate}, channels=${inspection.channels}, bitDepth=${inspection.bitDepth})`,
+      });
+      throw new Error('Audio validation failed');
+    }
+    finalPath = convertedPath;
+  }
+
+  console.log('[Import][Audio] resolved', {
+    originalPath,
+    resolvedPath: finalPath,
+    exists: fs.existsSync(finalPath),
+    sampleRate: inspection.sampleRate,
+    channels: inspection.channels,
+    bitDepth: inspection.bitDepth,
+    durationSec: Number(inspection.durationSec.toFixed(3)),
+  });
+
+  return {
+    originalPath,
+    resolvedPath: finalPath,
+    metadata: inspection,
+    wasConverted,
+  };
+}
+
+function collectCandidates(incomingPath: string | undefined, audioMetadata: any): string[] {
+  const candidates: string[] = [];
+  const possibleFields = [
+    incomingPath,
+    audioMetadata?.audioPath,
+    audioMetadata?.originalPath,
+    audioMetadata?.path,
+    audioMetadata?.embeddedPath,
+    audioMetadata?.fileName,
+  ];
+
+  const baseDirs = [
+    process.cwd(),
+    '/Users/chrismcleod/Development/ClaudeAccess/Working Audio',
+    '/Users/chrismcleod/Development/ChatAppAccess/Working Audio',
+    '/Users/chrismcleod/Development/ClaudeAccess/ClaudeTranscriptionProject',
+    '/Users/chrismcleod/Development/ClaudeAccess/ClaudeTranscriptionProject/audio',
+  ];
+
+  possibleFields.forEach(field => {
+    if (!field || typeof field !== 'string') {
+      return;
+    }
+
+    if (field.startsWith('file://')) {
+      const filePath = new URL(field).pathname;
+      candidates.push(path.normalize(filePath));
+      return;
+    }
+
+    if (path.isAbsolute(field)) {
+      candidates.push(path.normalize(field));
+      return;
+    }
+
+    const relative = field.replace(/^\.\//, '').replace(/^Audio Files[\/\\]/i, '');
+    baseDirs.forEach(dir => {
+      candidates.push(path.normalize(path.join(dir, relative)));
+    });
+  });
+
+  return Array.from(new Set(candidates));
+}
+
+function inspectWavHeaderSafe(filePath: string): WavMetadata | null {
+  try {
+    return inspectWavHeader(filePath);
+  } catch (error) {
+    return null;
+  }
+}
+
+function inspectWavHeader(filePath: string): WavMetadata {
+  const fd = fs.openSync(filePath, 'r');
+  try {
+    const stat = fs.fstatSync(fd);
+    const riffHeader = Buffer.alloc(12);
+    fs.readSync(fd, riffHeader, 0, 12, 0);
+    if (riffHeader.toString('ascii', 0, 4) !== 'RIFF' || riffHeader.toString('ascii', 8, 12) !== 'WAVE') {
+      throw new Error('Not a WAV file');
+    }
+
+    let offset = 12;
+    let fmtChunk: { sampleRate: number; channels: number; bitsPerSample: number; byteRate: number } | null = null;
+    let dataSize: number | null = null;
+
+    while (offset + 8 <= stat.size) {
+      const chunkHeader = Buffer.alloc(8);
+      fs.readSync(fd, chunkHeader, 0, 8, offset);
+      const chunkId = chunkHeader.toString('ascii', 0, 4);
+      const chunkSize = chunkHeader.readUInt32LE(4);
+      offset += 8;
+
+      if (chunkId === 'fmt ') {
+        const fmtBuffer = Buffer.alloc(chunkSize);
+        fs.readSync(fd, fmtBuffer, 0, chunkSize, offset);
+        const audioFormat = fmtBuffer.readUInt16LE(0);
+        if (audioFormat !== 1 && audioFormat !== 3) {
+          throw new Error(`Unsupported WAV format: ${audioFormat}`);
+        }
+        const channels = fmtBuffer.readUInt16LE(2);
+        const sampleRate = fmtBuffer.readUInt32LE(4);
+        const byteRate = fmtBuffer.readUInt32LE(8);
+        const bitsPerSample = fmtBuffer.readUInt16LE(14);
+        fmtChunk = { sampleRate, channels, bitsPerSample, byteRate };
+      } else if (chunkId === 'data') {
+        dataSize = chunkSize;
+        break;
+      }
+
+      offset += chunkSize + (chunkSize % 2);
+    }
+
+    if (!fmtChunk || dataSize === null) {
+      throw new Error('Incomplete WAV header');
+    }
+
+    const bytesPerSample = fmtChunk.bitsPerSample / 8;
+    const duration = dataSize / (fmtChunk.sampleRate * fmtChunk.channels * bytesPerSample);
+
+    return {
+      sampleRate: fmtChunk.sampleRate,
+      channels: fmtChunk.channels,
+      bitDepth: fmtChunk.bitsPerSample,
+      durationSec: duration,
+    };
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function isTargetWav(metadata: WavMetadata): boolean {
+  return (
+    metadata.sampleRate === TARGET_SAMPLE_RATE &&
+    metadata.channels === TARGET_CHANNELS &&
+    ALLOWED_BIT_DEPTHS.has(metadata.bitDepth)
+  );
+}
+
+async function convertToTargetWav(sourcePath: string): Promise<string> {
+  const directory = path.dirname(sourcePath);
+  const baseName = path.parse(sourcePath).name;
+  const targetPath = path.join(directory, `${baseName}_48000hz${WAV_EXTENSION}`);
+
+  await new Promise<void>((resolve, reject) => {
+    const ffmpeg = spawn('ffmpeg', [
+      '-i', sourcePath,
+      '-ar', TARGET_SAMPLE_RATE.toString(),
+      '-ac', TARGET_CHANNELS.toString(),
+      '-sample_fmt', 's16',
+      '-y',
+      targetPath,
+    ]);
+
+    ffmpeg.stderr.on('data', () => {
+      // consume stderr to avoid buffer overflow
+    });
+
+    ffmpeg.on('error', (error) => {
+      reject(error);
+    });
+
+    ffmpeg.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`ffmpeg exited with code ${code}`));
+      }
+    });
+  });
+
+  if (!fs.existsSync(targetPath)) {
+    throw new Error('Converted WAV was not created');
+  }
+
+  return targetPath;
+}

--- a/src/main/services/ImportAudioService.ts
+++ b/src/main/services/ImportAudioService.ts
@@ -7,6 +7,8 @@ export interface PreparedAudioResult {
   resolvedPath: string;
   metadata: WavMetadata;
   wasConverted: boolean;
+  candidates: string[];
+  probedDirs: string[];
 }
 
 export interface WavMetadata {
@@ -88,6 +90,8 @@ export async function prepareAudioForImport(
     resolvedPath: finalPath,
     metadata: inspection,
     wasConverted,
+    candidates,
+    probedDirs,
   };
 }
 

--- a/src/main/services/JuceClient.ts
+++ b/src/main/services/JuceClient.ts
@@ -855,6 +855,18 @@ export class JuceClient implements Transport {
 
   private handleLoadedEvent(evt: JuceEvent) {
     const eventGeneration = (evt as any).generationId;
+    const durationSec = typeof (evt as any).durationSec === 'number'
+      ? Number((evt as any).durationSec.toFixed(3))
+      : (evt as any).durationSec;
+    const sampleRate = (evt as any).sampleRate;
+    const channels = (evt as any).channels;
+    console.log('[JUCE] loaded', {
+      id: evt.id,
+      generationId: eventGeneration,
+      durationSec,
+      sampleRate,
+      channels,
+    });
     if (this.currentLoadCommand && this.currentLoadCommand.id === evt.id) {
       if (
         this.currentLoadCommand.generationId !== undefined &&

--- a/src/main/services/ProjectFileService.ts
+++ b/src/main/services/ProjectFileService.ts
@@ -323,12 +323,13 @@ export class ProjectFileService {
         projectData.project.audio = {} as any;
       }
       
-      // Set both extractedPath and embeddedPath to the temp extraction location
-      // to remain compatible with renderer code that expects embeddedPath.
-      projectData.project.audio.extractedPath = extractedAudioPath;
-      projectData.project.audio.embeddedPath = extractedAudioPath;
+      // Set originalFile to the extracted absolute temp file path for JUCE playback
+      projectData.project.audio.originalFile = extractedAudioPath;
+      projectData.project.audio.extractedPath = extractedAudioPath; // Compatibility
+      projectData.project.audio.embeddedPath = 'audio/audio.wav'; // Reference path inside zip
+      projectData.project.audio.embedded = true;
       projectData.project.audio.tempDirectory = tempDir;
-      console.log('Set extractedPath and embeddedPath in project.audio:', extractedAudioPath);
+      console.log('Set originalFile for JUCE playback:', extractedAudioPath);
       
       // Keep original metadata if available
       if (projectData.audioMetadata) {

--- a/src/renderer/components/ui/NewUIShellV2.tsx
+++ b/src/renderer/components/ui/NewUIShellV2.tsx
@@ -43,10 +43,10 @@ const NewUIShellV2: React.FC<NewUIShellV2Props> = ({ onManualSave }) => {
     }
 
     const candidates = [
-      audio?.path,
-      audio?.extractedPath,
-      audio?.embeddedPath,
-      audio?.originalFile,
+      audio?.originalFile,  // Primary source - always the playable 48kHz WAV
+      audio?.extractedPath, // Fallback for compatibility
+      audio?.embeddedPath,  // Won't be used directly (it's inside zip)
+      audio?.path,         // Legacy fallback
     ].filter((candidate): candidate is string => typeof candidate === 'string' && candidate.length > 0);
 
     if (candidates.length === 0) {
@@ -60,10 +60,10 @@ const NewUIShellV2: React.FC<NewUIShellV2Props> = ({ onManualSave }) => {
 
     return candidates[0] ?? null;
   }, [
-    projectState.projectData?.project?.audio?.path,
+    projectState.projectData?.project?.audio?.originalFile,
     projectState.projectData?.project?.audio?.extractedPath,
     projectState.projectData?.project?.audio?.embeddedPath,
-    projectState.projectData?.project?.audio?.originalFile,
+    projectState.projectData?.project?.audio?.path,
   ]);
 
   const [activePanel, setActivePanel] = useState<string>('transcript');

--- a/src/renderer/hooks/useAudioPlayback.ts
+++ b/src/renderer/hooks/useAudioPlayback.ts
@@ -549,6 +549,7 @@ export function useAudioPlayback(
 
     console.log('[Renderer][AudioPath] selected', {
       path: projectAudioPath,
+      source: 'originalFile', // Track which field provided the path
       exists: true,
       isAbsolute,
     });

--- a/src/renderer/services/TranscriptionImportService.ts
+++ b/src/renderer/services/TranscriptionImportService.ts
@@ -426,7 +426,7 @@ export class TranscriptionImportService {
           );
 
           segments.push(spacerSegment);
-          console.log('[Import][Spacer] segment', {
+          console.log('[Import][Spacer] segment created', {
             start: Number(spacerSegment.start.toFixed(3)),
             end: Number(spacerSegment.end.toFixed(3)),
             duration: Number(spacerSegment.duration.toFixed(3)),
@@ -447,7 +447,7 @@ export class TranscriptionImportService {
           );
 
           segments.push(spacerSegment);
-          console.log('[Import][Spacer] segment', {
+          console.log('[Import][Spacer] segment created', {
             start: Number(spacerSegment.start.toFixed(3)),
             end: Number(spacerSegment.end.toFixed(3)),
             duration: Number(spacerSegment.duration.toFixed(3)),
@@ -461,7 +461,7 @@ export class TranscriptionImportService {
         } else if (sanitizedGap === 0) {
           const spacerSegment = createSpacerSegment(wordEnd, wordEnd, '0.00s');
           segments.push(spacerSegment);
-          console.log('[Import][Spacer] segment', {
+          console.log('[Import][Spacer] segment created', {
             start: Number(spacerSegment.start.toFixed(3)),
             end: Number(spacerSegment.end.toFixed(3)),
             duration: Number(spacerSegment.duration.toFixed(3)),

--- a/src/renderer/services/TranscriptionImportService.ts
+++ b/src/renderer/services/TranscriptionImportService.ts
@@ -150,8 +150,8 @@ export class TranscriptionImportService {
         lastModified: new Date().toISOString(),
         version: '2.0',
         audio: {
-          ...audioMetadata,
-          path: audioFilePath // Ensure path is set for WAV conversion
+          ...audioMetadata
+          // originalFile should already be set correctly from audioMetadata
         },
         transcription: {
           service: 'openai', // TODO: Get from actual service

--- a/src/shared/__tests__/normalizeSegments.spec.ts
+++ b/src/shared/__tests__/normalizeSegments.spec.ts
@@ -1,0 +1,63 @@
+import { normalizeSegmentsForImport, validateNormalizedSegments } from '../operations';
+import { Segment } from '../types';
+
+describe('normalizeSegmentsForImport', () => {
+  const createWord = (id: string, start: number, end: number): Segment => ({
+    type: 'word',
+    id,
+    start,
+    end,
+    text: id,
+    confidence: 0.9,
+    originalStart: start,
+    originalEnd: end,
+  });
+
+  it('trims minor overlaps by adjusting previous end time', () => {
+    const segments: Segment[] = [
+      createWord('a', 0, 1.0),
+      createWord('b', 0.999, 1.5),
+    ];
+
+    const result = normalizeSegmentsForImport(segments);
+    expect(result.trimmedCount).toBeGreaterThan(0);
+    expect(result.shiftedCount).toBe(0);
+    expect(result.segments[0].end).toBeCloseTo(0.999, 3);
+    expect(result.segments[1].start).toBeCloseTo(0.999, 3);
+
+    expect(() => validateNormalizedSegments(result.segments)).not.toThrow();
+  });
+
+  it('shifts later segment when overlap exceeds threshold', () => {
+    const segments: Segment[] = [
+      createWord('a', 0, 1.0),
+      createWord('b', 0.8, 1.4),
+    ];
+
+    const result = normalizeSegmentsForImport(segments);
+    expect(result.shiftedCount).toBeGreaterThan(0);
+    expect(result.segments[1].start).toBeCloseTo(1.0, 3);
+    expect(result.segments[1].end).toBeGreaterThanOrEqual(result.segments[1].start);
+
+    expect(() => validateNormalizedSegments(result.segments)).not.toThrow();
+  });
+
+  it('removes zero-duration spacers', () => {
+    const segments: Segment[] = [
+      {
+        type: 'spacer',
+        id: 'spacer-1',
+        start: 1.0,
+        end: 1.0,
+        duration: 0,
+        label: '0s',
+      },
+      createWord('a', 1.0, 1.5),
+    ];
+
+    const result = normalizeSegmentsForImport(segments);
+    expect(result.removedCount).toBe(1);
+    expect(result.segments.length).toBe(1);
+    expect(result.segments[0].start).toBeCloseTo(1.0, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated import audio preparer that validates or converts sources to 48 kHz stereo WAV before import logging every step
- tighten transcription import logging, gap handling, and segment normalization with automatic overlap repair and stricter validation
- instrument transcription job progress logs in the main service and cover normalization repair scenarios with new Jest tests

## Testing
- npx jest --runTestsByPath src/shared/__tests__/normalizeSegments.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6df5484508333a72cef4d8ebce7bd