### PR TITLE
Improve JUCE recovery handshake and logging

### DIFF
--- a/src/shared/types/transport.ts
+++ b/src/shared/types/transport.ts
@@ -69,6 +69,8 @@ export type JuceEvent =
         spacerCount?: number;
         totalSegments?: number;
         mode?: 'contiguous' | 'standard' | string;
+        status?: 'ok' | 'error' | string;
+        message?: string;
       } & JuceEventBase)
   | ({ type: 'ended' } & JuceEventBase)
   | { type: 'error'; id?: TransportId; code?: string | number; message: string; generationId?: number }
@@ -132,7 +134,9 @@ export function isJuceEvent(obj: any): obj is JuceEvent {
         (obj.wordCount === undefined || typeof obj.wordCount === 'number') &&
         (obj.spacerCount === undefined || typeof obj.spacerCount === 'number') &&
         (obj.totalSegments === undefined || typeof obj.totalSegments === 'number') &&
-        (obj.mode === undefined || typeof obj.mode === 'string')
+        (obj.mode === undefined || typeof obj.mode === 'string') &&
+        (obj.status === undefined || typeof obj.status === 'string') &&
+        (obj.message === undefined || typeof obj.message === 'string')
       );
     case 'ended':
       return typeof obj.id === 'string';


### PR DESCRIPTION
## Summary
- add explicit load/EDL acknowledgement tracking so backend recoveries replay the last audio file and revision with recovery logs
- infer load readiness from edlApplied events and serialize play gate blockers for clearer renderer diagnostics
- mirror renderer readiness in the main process so play rejections while recovering emit structured reason codes

## Testing
- npm run build:main *(fails: repository lacks Node/Electron type configuration, so tsc reports missing globals)*

------
https://chatgpt.com/codex/tasks/task_e_68d81cdaf31c833395201d7664d13ce2